### PR TITLE
Google Drive integration is really fixed+

### DIFF
--- a/FilePicker/FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
+++ b/FilePicker/FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
@@ -49,9 +49,9 @@ namespace Plugin.FilePicker
                     var filePath = IOUtil.getPath (context, _uri);
 
                     if (string.IsNullOrEmpty (filePath))
-                        filePath = _uri.Path;
+                        filePath = IOUtil.isMediaStore(_uri.Scheme) ? _uri.ToString() : _uri.Path;
                     byte[] file;
-                    if (IOUtil.isMediaStore(filePath))
+                    if (IOUtil.isMediaStore(_uri.Scheme))
                         file = IOUtil.readFile(context, _uri);
                     else
                         file = IOUtil.readFile (filePath);


### PR DESCRIPTION
Changes your pull request #52 (https://github.com/Studyxnet/FilePicker-Plugin-for-Xamarin-and-Windows/pull/52) to really work with Google Drive.

Your implementation did not work on my Android 6.0 device - `DataArray` was always null when choosing a file from Google Drive because the internal `filePath` variable held an already truncated path.

You may want to merge this into your repository and enhance the pull request #52 to the original project.