### PR TITLE
Support for .NET Standard

### DIFF
--- a/FilePicker/FilePicker.sln
+++ b/FilePicker/FilePicker.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker", "FilePicker\Plugin.FilePicker\Plugin.FilePicker.csproj", "{A6FCEF44-D2BA-42C7-B3CB-13667BCD7B54}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Plugin.FilePicker", "FilePicker\Plugin.FilePicker\Plugin.FilePicker.csproj", "{A6FCEF44-D2BA-42C7-B3CB-13667BCD7B54}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker.Abstractions", "FilePicker\Plugin.FilePicker.Abstractions\Plugin.FilePicker.Abstractions.csproj", "{6EDB0588-FFC5-4EF5-8A99-9E241D0F878D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Plugin.FilePicker.Abstractions", "FilePicker\Plugin.FilePicker.Abstractions\Plugin.FilePicker.Abstractions.csproj", "{6EDB0588-FFC5-4EF5-8A99-9E241D0F878D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker.iOS", "FilePicker\Plugin.FilePicker.iOS\Plugin.FilePicker.iOS.csproj", "{2882AEEB-D4CD-4EB9-8A6C-6653B33681F0}"
 EndProject

--- a/FilePicker/FilePicker.sln
+++ b/FilePicker/FilePicker.sln
@@ -18,8 +18,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B5D9C3EE-C113-4BD5-9D91-248957142A8D}"
 	ProjectSection(SolutionItems) = preProject
 		..\LICENSE = ..\LICENSE
+		pt.Xamarin.Plugin.FilePicker.nuspec = pt.Xamarin.Plugin.FilePicker.nuspec
 		..\README.md = ..\README.md
-		..\Xamarin.Plugin.FilePicker.nuspec = ..\Xamarin.Plugin.FilePicker.nuspec
 	EndProjectSection
 EndProject
 Global

--- a/FilePicker/FilePicker.sln
+++ b/FilePicker/FilePicker.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker", "FilePicker\Plugin.FilePicker\Plugin.FilePicker.csproj", "{A6FCEF44-D2BA-42C7-B3CB-13667BCD7B54}"
 EndProject
@@ -11,13 +11,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker.iOS", "Fi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker.Android", "FilePicker\Plugin.FilePicker.Android\Plugin.FilePicker.Android.csproj", "{56A56F17-7DE1-4CA1-9617-BF32E971AC84}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker.WindowsStore", "FilePicker\Plugin.FilePicker.WindowsStore\Plugin.FilePicker.WindowsStore.csproj", "{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker.Mac", "FilePicker\Plugin.FilePicker.Mac\Plugin.FilePicker.Mac.csproj", "{C1E6D43D-38EB-4673-A9AA-8B1116CE9C10}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker.WindowsPhone8", "FilePicker\Plugin.FilePicker.WindowsPhone8\Plugin.FilePicker.WindowsPhone8.csproj", "{5876144B-47DD-4C4E-B421-BC03F191B996}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker.WindowsPhone81", "FilePicker\Plugin.FilePicker.WindowsPhone81\Plugin.FilePicker.WindowsPhone81.csproj", "{7169373F-0B82-4E5D-9129-7CC3065B90FA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker.UWP", "FilePicker\Plugin.FilePicker.UWP\Plugin.FilePicker.UWP.csproj", "{E34B516D-C0D8-450F-9DB0-BB6A5B04AEF1}"
 EndProject
@@ -140,30 +134,6 @@ Global
 		{56A56F17-7DE1-4CA1-9617-BF32E971AC84}.Release|x64.Build.0 = Release|Any CPU
 		{56A56F17-7DE1-4CA1-9617-BF32E971AC84}.Release|x86.ActiveCfg = Release|Any CPU
 		{56A56F17-7DE1-4CA1-9617-BF32E971AC84}.Release|x86.Build.0 = Release|Any CPU
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.AppStore|Any CPU.ActiveCfg = Release|Any CPU
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.AppStore|Any CPU.Build.0 = Release|Any CPU
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.AppStore|ARM.ActiveCfg = Release|ARM
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.AppStore|ARM.Build.0 = Release|ARM
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.AppStore|x64.ActiveCfg = Release|x64
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.AppStore|x64.Build.0 = Release|x64
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.AppStore|x86.ActiveCfg = Release|x86
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.AppStore|x86.Build.0 = Release|x86
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Debug|ARM.ActiveCfg = Debug|ARM
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Debug|ARM.Build.0 = Debug|ARM
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Debug|x64.ActiveCfg = Debug|x64
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Debug|x64.Build.0 = Debug|x64
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Debug|x86.ActiveCfg = Debug|x86
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Debug|x86.Build.0 = Debug|x86
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Release|Any CPU.Build.0 = Release|Any CPU
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Release|ARM.ActiveCfg = Release|ARM
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Release|ARM.Build.0 = Release|ARM
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Release|x64.ActiveCfg = Release|x64
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Release|x64.Build.0 = Release|x64
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Release|x86.ActiveCfg = Release|x86
-		{ED9A4CA1-C04C-457D-9A2E-7995CCF12356}.Release|x86.Build.0 = Release|x86
 		{C1E6D43D-38EB-4673-A9AA-8B1116CE9C10}.AppStore|Any CPU.ActiveCfg = Release|Any CPU
 		{C1E6D43D-38EB-4673-A9AA-8B1116CE9C10}.AppStore|Any CPU.Build.0 = Release|Any CPU
 		{C1E6D43D-38EB-4673-A9AA-8B1116CE9C10}.AppStore|ARM.ActiveCfg = Release|Any CPU
@@ -188,54 +158,6 @@ Global
 		{C1E6D43D-38EB-4673-A9AA-8B1116CE9C10}.Release|x64.Build.0 = Release|Any CPU
 		{C1E6D43D-38EB-4673-A9AA-8B1116CE9C10}.Release|x86.ActiveCfg = Release|Any CPU
 		{C1E6D43D-38EB-4673-A9AA-8B1116CE9C10}.Release|x86.Build.0 = Release|Any CPU
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.AppStore|Any CPU.ActiveCfg = Release|Any CPU
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.AppStore|Any CPU.Build.0 = Release|Any CPU
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.AppStore|ARM.ActiveCfg = Release|ARM
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.AppStore|ARM.Build.0 = Release|ARM
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.AppStore|x64.ActiveCfg = Release|Any CPU
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.AppStore|x64.Build.0 = Release|Any CPU
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.AppStore|x86.ActiveCfg = Release|x86
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.AppStore|x86.Build.0 = Release|x86
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Debug|ARM.ActiveCfg = Debug|ARM
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Debug|ARM.Build.0 = Debug|ARM
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Debug|x64.Build.0 = Debug|Any CPU
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Debug|x86.ActiveCfg = Debug|x86
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Debug|x86.Build.0 = Debug|x86
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Release|ARM.ActiveCfg = Release|ARM
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Release|ARM.Build.0 = Release|ARM
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Release|x64.ActiveCfg = Release|Any CPU
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Release|x64.Build.0 = Release|Any CPU
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Release|x86.ActiveCfg = Release|x86
-		{5876144B-47DD-4C4E-B421-BC03F191B996}.Release|x86.Build.0 = Release|x86
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.AppStore|Any CPU.ActiveCfg = Release|Any CPU
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.AppStore|Any CPU.Build.0 = Release|Any CPU
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.AppStore|ARM.ActiveCfg = Release|ARM
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.AppStore|ARM.Build.0 = Release|ARM
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.AppStore|x64.ActiveCfg = Release|Any CPU
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.AppStore|x64.Build.0 = Release|Any CPU
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.AppStore|x86.ActiveCfg = Release|x86
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.AppStore|x86.Build.0 = Release|x86
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Debug|ARM.ActiveCfg = Debug|ARM
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Debug|ARM.Build.0 = Debug|ARM
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Debug|x64.Build.0 = Debug|Any CPU
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Debug|x86.ActiveCfg = Debug|x86
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Debug|x86.Build.0 = Debug|x86
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Release|ARM.ActiveCfg = Release|ARM
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Release|ARM.Build.0 = Release|ARM
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Release|x64.ActiveCfg = Release|Any CPU
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Release|x64.Build.0 = Release|Any CPU
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Release|x86.ActiveCfg = Release|x86
-		{7169373F-0B82-4E5D-9129-7CC3065B90FA}.Release|x86.Build.0 = Release|x86
 		{E34B516D-C0D8-450F-9DB0-BB6A5B04AEF1}.AppStore|Any CPU.ActiveCfg = Release|Any CPU
 		{E34B516D-C0D8-450F-9DB0-BB6A5B04AEF1}.AppStore|Any CPU.Build.0 = Release|Any CPU
 		{E34B516D-C0D8-450F-9DB0-BB6A5B04AEF1}.AppStore|ARM.ActiveCfg = Release|ARM
@@ -263,5 +185,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F4A9BB87-000E-4FC8-B97D-7E98F6BE7DB7}
 	EndGlobalSection
 EndGlobal

--- a/FilePicker/FilePicker/Plugin.FilePicker.Abstractions/Plugin.FilePicker.Abstractions.csproj
+++ b/FilePicker/FilePicker/Plugin.FilePicker.Abstractions/Plugin.FilePicker.Abstractions.csproj
@@ -1,54 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <TargetFramework>netstandard1.0</TargetFramework>
     <ProjectGuid>{6EDB0588-FFC5-4EF5-8A99-9E241D0F878D}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Plugin.FilePicker.Abstractions</RootNamespace>
-    <AssemblyName>Plugin.FilePicker.Abstractions</AssemblyName>
-    <DefaultLanguage>en-US</DefaultLanguage>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Plugin.FilePicker.Abstractions.XML</DocumentationFile>
-  </PropertyGroup>
-  <ItemGroup>
-    <!-- A reference to the entire .NET Framework is automatically included -->
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="IFilePicker.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="FileData.cs" />
-    <Compile Include="FilePickerEventArgs.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/FilePicker/FilePicker/Plugin.FilePicker/CrossFilePicker.cs
+++ b/FilePicker/FilePicker/Plugin.FilePicker/CrossFilePicker.cs
@@ -28,7 +28,7 @@ namespace Plugin.FilePicker
 
         private static IFilePicker CreateFilePicker()
         {
-#if PORTABLE
+#if NETSTANDARD1_0
             return null;
 #else
             return new FilePickerImplementation();

--- a/FilePicker/FilePicker/Plugin.FilePicker/Plugin.FilePicker.csproj
+++ b/FilePicker/FilePicker/Plugin.FilePicker/Plugin.FilePicker.csproj
@@ -1,56 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <TargetFramework>netstandard1.0</TargetFramework>
     <ProjectGuid>{A6FCEF44-D2BA-42C7-B3CB-13667BCD7B54}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Plugin.FilePicker</RootNamespace>
-    <AssemblyName>Plugin.FilePicker</AssemblyName>
-    <DefaultLanguage>en-US</DefaultLanguage>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;PORTABLE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard1.0\Plugin.FilePicker.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;PORTABLE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Plugin.FilePicker.XML</DocumentationFile>
-  </PropertyGroup>
+
   <ItemGroup>
-    <!-- A reference to the entire .NET Framework is automatically included -->
-    <ProjectReference Include="..\Plugin.FilePicker.Abstractions\Plugin.FilePicker.Abstractions.csproj">
-      <Project>{6edb0588-ffc5-4ef5-8a99-9e241d0f878d}</Project>
-      <Name>Plugin.FilePicker.Abstractions</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Plugin.FilePicker.Abstractions\Plugin.FilePicker.Abstractions.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="CrossFilePicker.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/FilePicker/pt.Xamarin.Plugin.FilePicker.nuspec
+++ b/FilePicker/pt.Xamarin.Plugin.FilePicker.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata minClientVersion="2.8.1">
-       <id>Xamarin.Plugin.FilePicker</id>
+       <id>pt.Xamarin.Plugin.FilePicker</id>
        <version>2.0.0-beta</version>
        <title>FilePicker Plugin for Xamarin.Forms</title>
        <authors>Gerald Versluis, rafaelrmou, ArtjomP, vividos</authors>
@@ -16,17 +16,16 @@
        <summary>Simple cross-platform plug-in that allows you to pick files from the filesystem (iCloud drive in case of iOS) and work with them. View full project page for README
        </summary>
      <releaseNotes>
-     	[2.0] - Support for .NET Standard, removed Windows Phone 8 and Windows 8/8.1 support
-     	[1.4] - Support Xamarin.Mac
-		[1.3] - FileData now has a GetStream() method to retrieve the binary data as a Stream
-		[1.2] - Retrieve full file path from selected file
-		[1.1] - Support Windows Phone 8, 8.1 e Windows Store.
-		[1.0] - Pick files, save files and open the archive in Default App.
+      [2.0] - Support for .NET Standard, removed Windows Phone 8 and Windows 8/8.1 support
+      [1.4] - Support Xamarin.Mac
+      [1.3] - FileData now has a GetStream() method to retrieve the binary data as a Stream
+      [1.2] - Retrieve full file path from selected file
+      [1.1] - Support Windows Phone 8, 8.1 e Windows Store.
+      [1.0] - Pick files, save files and open the archive in Default App.
      </releaseNotes>
        <tags>xamarin, file, picker, filepicker, filebrowser, netstandard, plugin, plugin for xamarin, android, xamarin.forms, ios</tags>
    </metadata>
    <files>
-     <!--<file src="readme.txt" target="readme.txt" />-->
      <!--.NET Standard-->
      <file src="FilePicker\Plugin.FilePicker\bin\Release\netstandard1.0\Plugin.FilePicker.dll" target="lib\netstandard1.0\Plugin.FilePicker.dll" />
      <file src="FilePicker\Plugin.FilePicker\bin\Release\netstandard1.0\Plugin.FilePicker.xml" target="lib\netstandard1.0\Plugin.FilePicker.xml" />
@@ -39,10 +38,10 @@
      <file src="FilePicker\Plugin.FilePicker.Android\bin\Release\Plugin.FilePicker.dll" target="lib\MonoAndroid10\Plugin.FilePicker.dll" />
      <file src="FilePicker\Plugin.FilePicker.Android\bin\Release\Plugin.FilePicker.xml" target="lib\MonoAndroid10\Plugin.FilePicker.xml" />
      <file src="FilePicker\Plugin.FilePicker.Android\bin\Release\Plugin.FilePicker.pdb" target="lib\MonoAndroid10\Plugin.FilePicker.pdb" />
-     
      <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.dll" target="lib\MonoAndroid10\Plugin.FilePicker.Abstractions.dll" />
      <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.xml" target="lib\MonoAndroid10\Plugin.FilePicker.Abstractions.xml" />
      <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.pdb" target="lib\MonoAndroid10\Plugin.FilePicker.Abstractions.pdb" />
+
      <!--Xamarin.iOS-->
      <file src="FilePicker\Plugin.FilePicker.iOS\bin\iPhone\Release\Plugin.FilePicker.dll" target="lib\MonoTouch10\Plugin.FilePicker.dll" />
      <file src="FilePicker\Plugin.FilePicker.iOS\bin\iPhone\Release\Plugin.FilePicker.xml" target="lib\MonoTouch10\Plugin.FilePicker.xml" />
@@ -52,9 +51,9 @@
      <!--Xamarin.Mac-->
      <file src="FilePicker\Plugin.FilePicker.Mac\bin\Release\Plugin.FilePicker.dll" target="lib\Xamarin.Mac20\Plugin.FilePicker.dll" />
      <file src="FilePicker\Plugin.FilePicker.Mac\bin\Release\Plugin.FilePicker.xml" target="lib\Xamarin.Mac20\Plugin.FilePicker.xml" />
-    
      <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.dll" target="lib\Xamarin.Mac20\Plugin.FilePicker.Abstractions.dll" />
      <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.xml" target="lib\Xamarin.Mac20\Plugin.FilePicker.Abstractions.xml" />
+
      <!--UWP-->
      <file src="FilePicker\Plugin.FilePicker.UWP\bin\Release\Plugin.FilePicker.dll" target="lib\UAP10\Plugin.FilePicker.dll" />
      <file src="FilePicker\Plugin.FilePicker.UWP\bin\Release\Plugin.FilePicker.xml" target="lib\UAP10\Plugin.FilePicker.xml" />

--- a/README.md
+++ b/README.md
@@ -6,33 +6,32 @@ Simple cross-platform plug-in that allows you to pick files from the filesystem 
 [![NuGet version](https://badge.fury.io/nu/pt.Xamarin.Plugin.FilePicker.svg)](https://badge.fury.io/nu/pt.Xamarin.Plugin.FilePicker)
 
 * Available on NuGet: [FilePicker Nuget](https://www.nuget.org/packages/pt.Xamarin.Plugin.FilePicker/)
-* Install into your PCL project and Client projects.
+* Install into your Xamarin.Android, Xamarin.iOS, Xamarin.Forms, Xamarin.Mac project and Client projects.
 
 **Platform Support**
 
-|Platform|Supported|Version|
-| ------------------- | :-----------: | :------------------: |
-|Xamarin.iOS|Yes|iOS 6+|
-|Xamarin.iOS Unified|Yes|iOS 6+|
-|Xamarin.Android|Yes|API 10+|
-|Windows Phone Silverlight|No||
-|Windows Phone RT|Yes|8.1+|
-|Windows Store RT|Yes|8.1+|
-|Windows 10 UWP|Yes|10+|
-|Xamarin.Mac|Yes|* 10.12+|
+|Platform|Supported|Version|Remarks|
+| ------------------- | :-----------: | :------------------: | :------------------: |
+|Xamarin.iOS|Yes|iOS 6+||
+|Xamarin.iOS Unified|Yes|iOS 6+||
+|Xamarin.Android|Yes|API 10+||
+|Windows Phone Silverlight|No|||
+|Windows Phone RT|Yes|8.1+|Up to package version 1.3.x|
+|Windows Store RT|Yes|8.1+|Up to package version 1.3.x|
+|Windows 10 UWP|Yes|10+||
+|Xamarin.Mac|Yes|* 10.12+||
 
 \* The Xamarin.Mac implementaiton has only been tested on MacOS 10.12.
 
 ### API Usage
 
-Call **CrossFilePicker.Current** from any project or PCL to gain access to APIs.
+Call **CrossFilePicker.Current** from any platform or .NET Standard project to gain access to APIs.
 
 #### Example
 
             try
             {
-                FileData fileData = new FileData();
-                fileData = await CrossFilePicker.Current.PickFile();
+                FileData fileData = await CrossFilePicker.Current.PickFile();
                 string fileName = fileData.FileName;
                 string contents = System.Text.Encoding.UTF8.GetString(fileData.DataArray);
 
@@ -40,7 +39,8 @@ Call **CrossFilePicker.Current** from any project or PCL to gain access to APIs.
                 System.Console.WriteLine("File data: " + contents);
 
             }
-            catch (Exception e) {
+            catch (Exception e)
+            {
                 System.Console.WriteLine("Exception choosing file: " + e.ToString());
             }
 
@@ -54,7 +54,9 @@ Need [Configure iCloud Driver for your app](https://developer.xamarin.com/guides
 #### Contributors
 * [rafaelrmou](https://github.com/rafaelrmou)
 * [jfversluis](https://github.com/jfversluis)
- 
+* [ArtjomP](https://github.com/ArtjomP)
+* [vividos](https://github.com/vividos)
+
 Thanks!
 
 #### License

--- a/Xamarin.Plugin.FilePicker.nuspec
+++ b/Xamarin.Plugin.FilePicker.nuspec
@@ -11,57 +11,56 @@
        <!-- <iconUrl>https://github.com/ArtjomP/FilePicker-Plugin-for-Xamarin-and-Windows</iconUrl> -->
        <requireLicenseAcceptance>false</requireLicenseAcceptance>
        <description>
-         Simple cross-platform plug-in that allows you to pick files from the filesystem (iCloud drive in case of iOS) and work with them.
+         Simple cross-platform plug-in that allows you to pick files from the filesystem (iCloud drive in case of iOS) and work with them. Version 2.0 now supports .NET Standard and Visual Studio 2017.
        </description>
        <summary>Simple cross-platform plug-in that allows you to pick files from the filesystem (iCloud drive in case of iOS) and work with them. View full project page for README
        </summary>
      <releaseNotes>
-     	[2.0] - Removed Windows Phone 8 and Windows 8/8.1 support
+     	[2.0] - Support for .NET Standard, removed Windows Phone 8 and Windows 8/8.1 support
      	[1.4] - Support Xamarin.Mac
 		[1.3] - FileData now has a GetStream() method to retrieve the binary data as a Stream
 		[1.2] - Retrieve full file path from selected file
 		[1.1] - Support Windows Phone 8, 8.1 e Windows Store.
 		[1.0] - Pick files, save files and open the archive in Default App.
      </releaseNotes>
-       <tags>xamarin, file, picker, filepicker, filebrowser, pcl, xam.pcl, plugin, plugin for xamarin, windows phone, winphone, wp8, winrt, android, xamarin.forms, ios</tags>
+       <tags>xamarin, file, picker, filepicker, filebrowser, netstandard, plugin, plugin for xamarin, android, xamarin.forms, ios</tags>
    </metadata>
    <files>
      <!--<file src="readme.txt" target="readme.txt" />-->
-    <!--Core-->
-     <file src="FilePicker\Plugin.FilePicker\bin\Release\Plugin.FilePicker.dll" target="lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10\Plugin.FilePicker.dll" />
-     <file src="FilePicker\Plugin.FilePicker\bin\Release\Plugin.FilePicker.xml" target="lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10\Plugin.FilePicker.xml" />
-     <file src="FilePicker\Plugin.FilePicker\bin\Release\Plugin.FilePicker.pdb" target="lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10\Plugin.FilePicker.pdb" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.dll" target="lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10\Plugin.FilePicker.Abstractions.dll" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.xml" target="lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10\Plugin.FilePicker.Abstractions.xml" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.pdb" target="lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10\Plugin.FilePicker.Abstractions.pdb" />
-     
+     <!--.NET Standard-->
+     <file src="FilePicker\Plugin.FilePicker\bin\Release\netstandard1.0\Plugin.FilePicker.dll" target="lib\netstandard1.0\Plugin.FilePicker.dll" />
+     <file src="FilePicker\Plugin.FilePicker\bin\Release\netstandard1.0\Plugin.FilePicker.xml" target="lib\netstandard1.0\Plugin.FilePicker.xml" />
+     <file src="FilePicker\Plugin.FilePicker\bin\Release\netstandard1.0\Plugin.FilePicker.pdb" target="lib\netstandard1.0\Plugin.FilePicker.pdb" />
+     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.dll" target="lib\netstandard1.0\Plugin.FilePicker.Abstractions.dll" />
+     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.xml" target="lib\netstandard1.0\Plugin.FilePicker.Abstractions.xml" />
+     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.pdb" target="lib\netstandard1.0\Plugin.FilePicker.Abstractions.pdb" />
 
      <!--Xamarin.Android-->
      <file src="FilePicker\Plugin.FilePicker.Android\bin\Release\Plugin.FilePicker.dll" target="lib\MonoAndroid10\Plugin.FilePicker.dll" />
      <file src="FilePicker\Plugin.FilePicker.Android\bin\Release\Plugin.FilePicker.xml" target="lib\MonoAndroid10\Plugin.FilePicker.xml" />
      <file src="FilePicker\Plugin.FilePicker.Android\bin\Release\Plugin.FilePicker.pdb" target="lib\MonoAndroid10\Plugin.FilePicker.pdb" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.dll" target="lib\MonoAndroid10\Plugin.FilePicker.Abstractions.dll" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.xml" target="lib\MonoAndroid10\Plugin.FilePicker.Abstractions.xml" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.pdb" target="lib\MonoAndroid10\Plugin.FilePicker.Abstractions.pdb" />
      
+     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.dll" target="lib\MonoAndroid10\Plugin.FilePicker.Abstractions.dll" />
+     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.xml" target="lib\MonoAndroid10\Plugin.FilePicker.Abstractions.xml" />
+     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.pdb" target="lib\MonoAndroid10\Plugin.FilePicker.Abstractions.pdb" />
      <!--Xamarin.iOS-->
      <file src="FilePicker\Plugin.FilePicker.iOS\bin\iPhone\Release\Plugin.FilePicker.dll" target="lib\MonoTouch10\Plugin.FilePicker.dll" />
      <file src="FilePicker\Plugin.FilePicker.iOS\bin\iPhone\Release\Plugin.FilePicker.xml" target="lib\MonoTouch10\Plugin.FilePicker.xml" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.dll" target="lib\MonoTouch10\Plugin.FilePicker.Abstractions.dll" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.xml" target="lib\MonoTouch10\Plugin.FilePicker.Abstractions.xml" />
+     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.dll" target="lib\MonoTouch10\Plugin.FilePicker.Abstractions.dll" />
+     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.xml" target="lib\MonoTouch10\Plugin.FilePicker.Abstractions.xml" />
 
      <!--Xamarin.Mac-->
      <file src="FilePicker\Plugin.FilePicker.Mac\bin\Release\Plugin.FilePicker.dll" target="lib\Xamarin.Mac20\Plugin.FilePicker.dll" />
      <file src="FilePicker\Plugin.FilePicker.Mac\bin\Release\Plugin.FilePicker.xml" target="lib\Xamarin.Mac20\Plugin.FilePicker.xml" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.dll" target="lib\Xamarin.Mac20\Plugin.FilePicker.Abstractions.dll" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.xml" target="lib\Xamarin.Mac20\Plugin.FilePicker.Abstractions.xml" />
     
+     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.dll" target="lib\Xamarin.Mac20\Plugin.FilePicker.Abstractions.dll" />
+     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.xml" target="lib\Xamarin.Mac20\Plugin.FilePicker.Abstractions.xml" />
      <!--UWP-->
      <file src="FilePicker\Plugin.FilePicker.UWP\bin\Release\Plugin.FilePicker.dll" target="lib\UAP10\Plugin.FilePicker.dll" />
      <file src="FilePicker\Plugin.FilePicker.UWP\bin\Release\Plugin.FilePicker.xml" target="lib\UAP10\Plugin.FilePicker.xml" />
      <file src="FilePicker\Plugin.FilePicker.UWP\bin\Release\Plugin.FilePicker.pdb" target="lib\UAP10\Plugin.FilePicker.pdb" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.dll" target="lib\UAP10\Plugin.FilePicker.Abstractions.dll" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.xml" target="lib\UAP10\Plugin.FilePicker.Abstractions.xml" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.pdb" target="lib\UAP10\Plugin.FilePicker.Abstractions.pdb" />
+     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.dll" target="lib\UAP10\Plugin.FilePicker.Abstractions.dll" />
+     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.xml" target="lib\UAP10\Plugin.FilePicker.Abstractions.xml" />
+     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\netstandard1.0\Plugin.FilePicker.Abstractions.pdb" target="lib\UAP10\Plugin.FilePicker.Abstractions.pdb" />
    </files>
 </package>

--- a/Xamarin.Plugin.FilePicker.nuspec
+++ b/Xamarin.Plugin.FilePicker.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
    <metadata minClientVersion="2.8.1">
        <id>Xamarin.Plugin.FilePicker</id>
-       <version>1.4.0-beta</version>
+       <version>2.0.0-beta</version>
        <title>FilePicker Plugin for Xamarin.Forms</title>
-       <authors>Gerald Versluis, rafaelrmou</authors>
+       <authors>Gerald Versluis, rafaelrmou, ArtjomP, vividos</authors>
        <owners>Gerald Versluis</owners>
-       <licenseUrl>https://github.com/jfversluis/FilePicker-Plugin-for-Xamarin-and-Windows/blob/master/LICENSE</licenseUrl>
-       <projectUrl>https://github.com/jfversluis/FilePicker-Plugin-for-Xamarin-and-Windows</projectUrl>
-       <!-- <iconUrl>https://github.com/jfversluis/FilePicker-Plugin-for-Xamarin-and-Windows</iconUrl> -->
+       <licenseUrl>https://github.com/ArtjomP/FilePicker-Plugin-for-Xamarin-and-Windows/blob/master/LICENSE</licenseUrl>
+       <projectUrl>https://github.com/ArtjomP/FilePicker-Plugin-for-Xamarin-and-Windows</projectUrl>
+       <!-- <iconUrl>https://github.com/ArtjomP/FilePicker-Plugin-for-Xamarin-and-Windows</iconUrl> -->
        <requireLicenseAcceptance>false</requireLicenseAcceptance>
        <description>
          Simple cross-platform plug-in that allows you to pick files from the filesystem (iCloud drive in case of iOS) and work with them.

--- a/Xamarin.Plugin.FilePicker.nuspec
+++ b/Xamarin.Plugin.FilePicker.nuspec
@@ -16,6 +16,7 @@
        <summary>Simple cross-platform plug-in that allows you to pick files from the filesystem (iCloud drive in case of iOS) and work with them. View full project page for README
        </summary>
      <releaseNotes>
+     	[2.0] - Removed Windows Phone 8 and Windows 8/8.1 support
      	[1.4] - Support Xamarin.Mac
 		[1.3] - FileData now has a GetStream() method to retrieve the binary data as a Stream
 		[1.2] - Retrieve full file path from selected file
@@ -33,31 +34,6 @@
      <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.dll" target="lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10\Plugin.FilePicker.Abstractions.dll" />
      <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.xml" target="lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10\Plugin.FilePicker.Abstractions.xml" />
      <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.pdb" target="lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10+UAP10\Plugin.FilePicker.Abstractions.pdb" />
-     
-     <!--Win Phone Silverlight-->
-     <file src="FilePicker\Plugin.FilePicker.WindowsPhone8\bin\Release\Plugin.FilePicker.dll" target="lib\wp8\Plugin.FilePicker.dll" />
-     <file src="FilePicker\Plugin.FilePicker.WindowsPhone8\bin\Release\Plugin.FilePicker.xml" target="lib\wp8\Plugin.FilePicker.xml" />
-     <file src="FilePicker\Plugin.FilePicker.WindowsPhone8\bin\Release\Plugin.FilePicker.pdb" target="lib\wp8\Plugin.FilePicker.pdb" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.dll" target="lib\wp8\Plugin.FilePicker.Abstractions.dll" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.xml" target="lib\wp8\Plugin.FilePicker.Abstractions.xml" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.pdb" target="lib\wp8\Plugin.FilePicker.Abstractions.pdb" />
-     
-     <!--Win Phone 81-->
-     <file src="FilePicker\Plugin.FilePicker.WindowsPhone81\bin\Release\Plugin.FilePicker.dll" target="lib\wpa81\Plugin.FilePicker.dll" />
-     <file src="FilePicker\Plugin.FilePicker.WindowsPhone81\bin\Release\Plugin.FilePicker.xml" target="lib\wpa81\Plugin.FilePicker.xml" />
-     <file src="FilePicker\Plugin.FilePicker.WindowsPhone81\bin\Release\Plugin.FilePicker.pdb" target="lib\wpa81\Plugin.FilePicker.pdb" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.dll" target="lib\wpa81\Plugin.FilePicker.Abstractions.dll" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.xml" target="lib\wpa81\Plugin.FilePicker.Abstractions.xml" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.pdb" target="lib\wpa81\Plugin.FilePicker.Abstractions.pdb" />
-     
-
-     <!--WinStore-->
-     <file src="FilePicker\Plugin.FilePicker.WindowsStore\bin\Release\Plugin.FilePicker.dll" target="lib\win8\Plugin.FilePicker.dll" />
-     <file src="FilePicker\Plugin.FilePicker.WindowsStore\bin\Release\Plugin.FilePicker.xml" target="lib\win8\Plugin.FilePicker.xml" />
-     <file src="FilePicker\Plugin.FilePicker.WindowsStore\bin\Release\Plugin.FilePicker.pdb" target="lib\win8\Plugin.FilePicker.pdb" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.dll" target="lib\win8\Plugin.FilePicker.Abstractions.dll" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.xml" target="lib\win8\Plugin.FilePicker.Abstractions.xml" />
-     <file src="FilePicker\Plugin.FilePicker.Abstractions\bin\Release\Plugin.FilePicker.Abstractions.pdb" target="lib\win8\Plugin.FilePicker.Abstractions.pdb" />
      
 
      <!--Xamarin.Android-->


### PR DESCRIPTION
Xamarin app development in Visual Studio 2017 is going to adapt .NET Standard libraries more and more. Most of the Xamarin.Plugin libraries that I'm using in my project were already ported to use .NET Standard (Geolocator, External Maps, Permissions, etc.). FilePicker is still using PCL, so I set out to port it to .NET Standard.

Here is a pull request with my porting efforts. Please check each commit and accept it, request modifications or cherry-pick changes as you like.

Unfortunately when developing with Visual Studio 2017, Microsoft dropped support for Windows 8.1 and Windows Phone 8.1, so I also had to remove it from the .sln file. The projects are still there.
I also moved and modified the .nuspec file, as in the current location no package could be built. I set the version to "2.0.0-beta", which should allow publishing the package to NuGet.org without disturbing users of previous versions.

The projects build without errors and the "nuget pack" generates a NuGet package that works in my Android-only project. As the platform-dependent projects weren't touched, I expect that other platforms work OK, too.

Finally, maybe this Pull Request should go into a "2.0" or "net standard" branch, since maybe more 1.3.x or 1.4.x versions are needed. I hope my contribution is useful for someone!